### PR TITLE
switch to compile target of Java 8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -41,8 +41,8 @@
 
     <properties>
         <liquibase.version>4.28.0</liquibase.version>
-        <maven.compiler.source>17</maven.compiler.source>
-        <maven.compiler.target>17</maven.compiler.target>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
         <sonar.organization>liquibase</sonar.organization>
         <sonar.projectKey>${sonar.organization}_${project.artifactId}</sonar.projectKey>
         <sonar.projectName>${project.name}</sonar.projectName>


### PR DESCRIPTION
For now, Liquibase is expected to be compatible with Java 8, so all extensions should also follow this pattern.