### PR TITLE
🔧 DAT-18941: Update dependabot.yml 

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,11 +3,27 @@ updates:
 
   - package-ecosystem: "github-actions"
     directory: "/"
+    open-pull-requests-limit: 50
     schedule:
       interval: "daily"
 
   - package-ecosystem: "maven"
     directory: "/"
+    open-pull-requests-limit: 50
+    labels:
+      - "sdou"
     schedule:
       interval: "daily"
+    pull-request-branch-name:
+      # Separate sections of the branch name with a hyphen
+      # for example, `dependabot-npm_and_yarn-next_js-acorn-6.4.1`
+      separator: "-"
+    registries:
+      - github
 
+registries:
+  github:
+    type: "maven-repository"
+    url: "https://maven.pkg.github.com/"
+    username: "liquibot"
+    password: "${{secrets.LIQUIBOT_PAT_GPM_ACCESS}}"


### PR DESCRIPTION
This pull request includes several updates to the `.github/dependabot.yml` file to enhance the configuration for dependency updates. The main changes involve setting limits on open pull requests, adding labels, customizing branch names, and configuring registries.

Configuration updates:

* Set `open-pull-requests-limit` to 50 for both `github-actions` and `maven` ecosystems.
* Added a `labels` section with the label "sdou" for the `maven` ecosystem.
* Customized the `pull-request-branch-name` for the `maven` ecosystem to use a hyphen as a separator.
* Added a `registries` section for the `maven` ecosystem, including a new `github` registry configuration.